### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/Sweepbot.py
+++ b/Sweepbot.py
@@ -22,7 +22,7 @@ def putbalance(balance):
 	f.write(str(balance))
 	f.close
 
-access = ServiceProxy("http://%s:%s@127.0.0.1:8332" % (rpcuser,rpcpassword))
+access = ServiceProxy("http://{0!s}:{1!s}@127.0.0.1:8332".format(rpcuser, rpcpassword))
 
 def proccess(force):
 	access.settxfee(0)
@@ -32,7 +32,7 @@ def proccess(force):
 	if ((balance > lastbalance) or force):
 		access.sendtoaddress(savings,balance)
 		putbalance(balance)
-	print "balance: %s,lastbalance: %s " % (balance,lastbalance)
+	print "balance: {0!s},lastbalance: {1!s} ".format(balance, lastbalance)
 
 def main():
       	parser = OptionParser()

--- a/Sweepbot2.py
+++ b/Sweepbot2.py
@@ -23,7 +23,7 @@ addnodes = [("127.0.0.1",8333),("respends.thinlink.com",8333),("68.168.105.168",
 txcache = {}
 pkcache = {}
 
-access = ServiceProxy("http://%s:%s@127.0.0.1:8332" % (rpcuser,rpcpassword))
+access = ServiceProxy("http://{0!s}:{1!s}@127.0.0.1:8332".format(rpcuser, rpcpassword))
 
 def make_request(*args):
     opener = urllib2.build_opener()
@@ -36,7 +36,7 @@ def make_request(*args):
         raise Exception(p)
 
 def sendblockchain(priv,address,amount,fee):
-	url =  "https://blockchain.info/merchant/%s/payment?to=%s&amount=%s&fee=%s" % (priv,address,amount,fee)
+	url =  "https://blockchain.info/merchant/{0!s}/payment?to={1!s}&amount={2!s}&fee={3!s}".format(priv, address, amount, fee)
 
 	#print url
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:daedalus:Sweepbot?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:daedalus:Sweepbot?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
